### PR TITLE
Add PyPI publish workflow and bump version to 0.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bibfixer"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fixes and standardizes BibTeX using LLM + web search"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`publish.yml`) that publishes to PyPI via trusted publisher when a release is created
- Bump version from 0.2.0 to 0.3.0

## To publish
1. Merge this PR
2. Create a GitHub release with tag `v0.3.0`
3. Workflow automatically builds and publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)